### PR TITLE
Properly apply ProxyCheckSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,17 +172,20 @@ public class DashboardExample {
 package io.github.defiancecoding.proxycheck.examples;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.github.defiancecoding.proxycheck.api.proxycheck.check.ProxyCheck;
 import io.github.defiancecoding.proxycheck.api.proxycheck.check.ProxyCheckSettings;
 import io.github.defiancecoding.proxycheck.api.proxycheck.check.results.ProxyResults;
 
 import java.io.IOException;
 
-public class ProxyCheck {
+public class ProxyCheckExample {
 
-    private static io.github.defiancecoding.proxycheck.api.proxycheck.check.ProxyCheck proxyCheck = new io.github.defiancecoding.proxycheck.api.proxycheck.check.ProxyCheck();
-    private static ProxyCheckSettings settings = new ProxyCheckSettings();
-    
-    private static void setupProxycheckSettings(){
+    /**
+     * Please note the settings below will throw a NPE , These settings are merely an example and you shouldn't need all
+     * the settings anyway.
+     */
+    private static ProxyCheck createProxyCheck(){
+        ProxyCheckSettings settings = new ProxyCheckSettings();
         settings.setApi_key("APIKey");
         settings.setCheck_vpn(true);
         settings.setCheck_asn(true);
@@ -194,11 +197,12 @@ public class ProxyCheck {
         settings.setMax_detection_days(7);
         settings.setVer("Ver");
         settings.setTag("ProxyCheckJavaAPI");
-
+        return new ProxyCheck(settings);
     }
 
     public static void main(String args[]) throws IOException {
-        setupProxycheckSettings();
+        // Create a new ProxyCheck instance
+        ProxyCheck proxyCheck = createProxyCheck();
         
         // Get reponse as a Json but in String format
         String jsonReponse = proxyCheck.getLookupResponse("1.1.1.1");
@@ -213,7 +217,6 @@ public class ProxyCheck {
         String asn = results.getAsn();
         String proxy = results.getProxy();
         //.... keep going
-        
     }
 
 }

--- a/src/main/java/io/github/defiancecoding/proxycheck/api/proxycheck/check/ProxyCheck.java
+++ b/src/main/java/io/github/defiancecoding/proxycheck/api/proxycheck/check/ProxyCheck.java
@@ -9,9 +9,25 @@ import io.github.defiancecoding.proxycheck.api.webconnection.HTTPQuery;
 
 public class ProxyCheck
 {
-  private final ProxyCheckSettings settings = new ProxyCheckSettings();
-  private final HTTPQuery httpQuery = new HTTPQuery();
+  private final ProxyCheckSettings settings;
+  private final HTTPQuery httpQuery;
 
+  /**
+   * Constructs a new ProxyCheck instance with default settings
+   */
+  public ProxyCheck() {
+      this(new ProxyCheckSettings());
+  }
+  
+  /**
+   * Constructs a new ProxyCheck instance
+   * @param settings API settings for ProxyCheck queries
+   */
+  public ProxyCheck(ProxyCheckSettings settings) {
+      this.settings = settings;
+      this.httpQuery = new HTTPQuery();
+  }
+  
   /**
    * Builds the API URL based on selected settings
    *

--- a/src/main/java/io/github/defiancecoding/proxycheck/examples/ProxyCheckExample.java
+++ b/src/main/java/io/github/defiancecoding/proxycheck/examples/ProxyCheckExample.java
@@ -9,16 +9,14 @@ import java.io.IOException;
 
 public class ProxyCheckExample {
 
-    private static ProxyCheck proxyCheck = new ProxyCheck();
-    private static ProxyCheckSettings settings = new ProxyCheckSettings();
-
     /**
      * Please note the settings below will throw a NPE , These settings are merely an example and you shouldn't need all
      * the settings anywho.
      *
      */
 
-    private static void setupProxycheckSettings(){
+    private static ProxyCheck createProxyCheck(){
+        ProxyCheckSettings settings = new ProxyCheckSettings();
         settings.setApi_key("APIKey");
         settings.setCheck_vpn(true);
         settings.setCheck_asn(true);
@@ -30,11 +28,11 @@ public class ProxyCheckExample {
         settings.setMax_detection_days(7);
         settings.setVer("Ver");
         settings.setTag("ProxyCheckJavaAPI");
-
+        return new ProxyCheck(settings);
     }
 
     public static void main(String args[]) throws IOException {
-        setupProxycheckSettings();
+        ProxyCheck proxyCheck = createProxyCheck();
 
         // Get reponse as a Json but in String format
         String jsonReponse = proxyCheck.getLookupResponse("1.1.1.1");
@@ -49,7 +47,6 @@ public class ProxyCheckExample {
         String asn = results.getAsn();
         String proxy = results.getProxy();
         //.... keep going
-
     }
 
 }

--- a/src/main/java/io/github/defiancecoding/proxycheck/examples/ProxyCheckExample.java
+++ b/src/main/java/io/github/defiancecoding/proxycheck/examples/ProxyCheckExample.java
@@ -11,10 +11,8 @@ public class ProxyCheckExample {
 
     /**
      * Please note the settings below will throw a NPE , These settings are merely an example and you shouldn't need all
-     * the settings anywho.
-     *
+     * the settings anyway.
      */
-
     private static ProxyCheck createProxyCheck(){
         ProxyCheckSettings settings = new ProxyCheckSettings();
         settings.setApi_key("APIKey");


### PR DESCRIPTION
# Properly apply ProxyCheckSettings

Currently the `ProxyCheck` class does not allow for a custom `ProxyCheckSettings` to be applied. This PR resolves this by allowing the settings class to be passed to the constructor. I also went ahead and updated the `ProxyCheckExample` to reflect this change. 

I left a default constructer in place to keep these changes backwards compatible, though I would highly suggest removing the hard-coded API key [here](https://github.com/DefianceCoding/ProxyCheckJavaAPIV2/blob/master/src/main/java/io/github/defiancecoding/proxycheck/api/proxycheck/check/ProxyCheckSettings.java#L5) and have the constructor with `ProxyCheckSettings` be the only way to initialize the class.

Signed-off-by: applenick <applenick@users.noreply.github.com>